### PR TITLE
Prevent outside-bounds crash when actually zeroing out heap

### DIFF
--- a/ocaml-offchain/interpreter/merkle/merkle.ml
+++ b/ocaml-offchain/interpreter/merkle/merkle.ml
@@ -392,7 +392,7 @@ let generic_stub m inst mname fname =
 *)
 
 let mem_init_size m =
-  if !Flags.run_wasm || !Flags.disable_float then Byteutil.pow2 (!Flags.memory_size - 13) else
+  if !Flags.run_wasm || !Flags.disable_float then Byteutil.pow2 (!Flags.memory_size) / 65336 else
   let open Ast in
   let open Types in
   let open Source in


### PR DESCRIPTION
This one might need a bit closer review

While porting tinygo to TrueBit, I hit that it was unable to zero the heap up to the end of memory.size as reported by the WASM VM, getting a out of bounds error

Memory_size in the following is -memory-size as provided to the interpreter - which I understand as making the task able to access up to 2^(memory_size)

When the TrueBit VM is initialized, a calculation is made to GROW wasm memory with 2^(memory_size - 13) pages (of 65536 byte size each) ---

but SETMEMORY only with 2^(memory_size) is done (actually allocates the memory array)!

And then when memory.size is asked by a program, 2^(memory_size - 13) is returned, which is interpreted as 2^(memory_size - 13) * 65536

Example problem, memory_size = 25

2^25 = 33554432 (32mb)

2^(25-13)* 65536 = 268435456 (256mb)

This patch makes GROW amount of 2^(memory_size)  / 65536 pages instead, aligning with what's actually being allocated 