### PR TITLE
feat: updated geth 1.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN cd bin \
 
 # Install Geth
 FROM stage-base-plain AS stage-Geth
-RUN wget https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.12.0-e501b3b0.tar.gz \
+RUN wget https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.12.2-bed84606.tar.gz \
     && tar xf geth*tar.gz \
     && rm geth*tar.gz \
     && cd geth*
@@ -115,8 +115,8 @@ RUN wget https://dist.ipfs.io/go-ipfs/v0.7.0/go-ipfs_v0.7.0_linux-amd64.tar.gz \
 # Final Image
 FROM stage-base-02 as final-image
 COPY --from=stage-Solidity /bin/solc /bin/
-COPY --from=stage-Geth /geth-alltools-linux-amd64-1.12.0-e501b3b0/geth  /bin/
-COPY --from=stage-Geth /geth-alltools-linux-amd64-1.12.0-e501b3b0/clef  /bin/
+COPY --from=stage-Geth /geth-alltools-linux-amd64-1.12.2-bed84606/geth  /bin/
+COPY --from=stage-Geth /geth-alltools-linux-amd64-1.12.2-bed84606/clef  /bin/
 COPY --from=stage-Prysm /ethereum /ethereum
 COPY --from=stage-IPFS /usr/local/bin/ipfs /usr/local/bin/
 COPY . truebit-eth/


### PR DESCRIPTION
Updated geth 1.12.2
A crash related to leveldb metrics is resolved 
Metrics names used by the blobpool have been changed to be compatible with Prometheus 
